### PR TITLE
Prevent fake submissions

### DIFF
--- a/src/main/java/io/droptracker/util/ContainerManager.java
+++ b/src/main/java/io/droptracker/util/ContainerManager.java
@@ -81,7 +81,7 @@ public class ContainerManager {
                 }
             }
         }
-
+        currentQuantity += receivedItem.getQuantity();
         // If current quantity is greater than previous quantity, it's a real drop
         if (currentQuantity > previousQuantity) {
             return true;

--- a/src/main/java/io/droptracker/util/ContainerManager.java
+++ b/src/main/java/io/droptracker/util/ContainerManager.java
@@ -1,63 +1,93 @@
-//package io.droptracker.util;
-//
-//import io.droptracker.DropTrackerPlugin;
-//import net.runelite.api.*;
-//
-//
-//public class ContainerManager {
-//    /**
-//     * Helps to determine whether or not the player's newly "received" item
-//     * Actually came from a loot-related event, or if it was just a result of swapping gear/looting pre-existing ground items
-//     * on the same game tick that a loot-related event occurred.
-//     */
-//
-//    private final DropTrackerPlugin plugin;
-//    private final Client client;
-//
-//    private Item[] lastInventoryState;
-//    private Item[] lastEquipmentState;
-//
-//    public ContainerManager(DropTrackerPlugin plugin, Client client) {
-//        this.plugin = plugin;
-//        this.client = client;
-//    }
-//
-//    public void onTick() {
-//        ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
-//        ItemContainer worn = client.getItemContainer(InventoryID.EQUIPMENT);
-//
-//        if (inventory != null) {
-//            lastInventoryState = inventory.getItems().clone();
-//        }
-//        if (worn != null) {
-//            lastEquipmentState = worn.getItems().clone();
-//        }
-//    }
-//
-//    public boolean isRealDrop(Item receivedItem) {
-//        /** Determine if the drop is 'real' by checking the last stored inventory/worn equipment
-//         * against the item. If the item was added to their containers on the same tick as a kill,
-//         * we can assume it was not a real drop...?
-//         * The only place I would see this potentially not working is with row(i) for coins(?)
-//         * */
-//        if (lastInventoryState != null) {
-//            for (Item item : lastInventoryState) {
-//                if (item != null && item.getId() == receivedItem.getId()) {
-//                    System.out.println("Drop ignored as it was determined to be pre-existing.");
-//                    return false;
-//                }
-//            }
-//        }
-//
-//        if (lastEquipmentState != null) {
-//            for (Item item : lastEquipmentState) {
-//                if (item != null && item.getId() == receivedItem.getId()) {
-//                    System.out.println("Drop ignored as it was determined to be pre-existing.");
-//                    return false;
-//                }
-//            }
-//        }
-//
-//        return true;
-//    }
-//}
+package io.droptracker.util;
+
+import io.droptracker.DropTrackerPlugin;
+import net.runelite.api.*;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class ContainerManager {
+    /**
+     * Helps to determine whether or not the player's newly "received" item
+     * Actually came from a loot-related event, or if it was just a result of swapping gear/looting pre-existing ground items
+     * on the same game tick that a loot-related event occurred.
+     */
+
+    private final DropTrackerPlugin plugin;
+    private final Client client;
+
+    private Item[] lastInventoryState;
+    private Item[] lastEquipmentState;
+
+    @Inject
+    public ContainerManager(DropTrackerPlugin plugin, Client client) {
+        this.plugin = plugin;
+        this.client = client;
+    }
+
+    public void onTick() {
+        ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
+        ItemContainer worn = client.getItemContainer(InventoryID.EQUIPMENT);
+
+        if (inventory != null) {
+            lastInventoryState = inventory.getItems().clone();
+        }
+        if (worn != null) {
+            lastEquipmentState = worn.getItems().clone();
+        }
+    }
+
+    public boolean isRealDrop(Item receivedItem) {
+        /** Determine if the drop is 'real' by checking the last stored inventory/worn equipment
+         * against the item. If the item was added to their containers on the same tick as a kill,
+         * we can assume it was not a real drop...?
+         * The only place I would see this potentially not working is with row(i) for coins(?)
+         * */
+        int previousQuantity = 0;
+
+        if (lastInventoryState != null) {
+            for (Item item : lastInventoryState) {
+                if (item != null && item.getId() == receivedItem.getId()) {
+                    previousQuantity += item.getQuantity();
+                }
+            }
+        }
+
+        if (lastEquipmentState != null) {
+            for (Item item : lastEquipmentState) {
+                if (item != null && item.getId() == receivedItem.getId()) {
+                    previousQuantity += item.getQuantity();
+                }
+            }
+        }
+
+        // Get current quantity from both containers
+        int currentQuantity = 0;
+        ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
+        ItemContainer equipment = client.getItemContainer(InventoryID.EQUIPMENT);
+
+        if (inventory != null) {
+            for (Item item : inventory.getItems()) {
+                if (item != null && item.getId() == receivedItem.getId()) {
+                    currentQuantity += item.getQuantity();
+                }
+            }
+        }
+
+        if (equipment != null) {
+            for (Item item : equipment.getItems()) {
+                if (item != null && item.getId() == receivedItem.getId()) {
+                    currentQuantity += item.getQuantity();
+                }
+            }
+        }
+
+        // If current quantity is greater than previous quantity, it's a real drop
+        if (currentQuantity > previousQuantity) {
+            return true;
+        }
+
+        System.out.println("Drop ignored as it was determined to be pre-existing. Previous qty: " + previousQuantity + ", Current qty: " + currentQuantity);
+        return false;
+    }
+}


### PR DESCRIPTION
Adds a class, `ContainerManager`, which attempts to track players' container statuses (inventory, equipment, etc) and prevent "fake" submissions from being sent to our database.

In summary, RuneLite determines that a drop has been received by an NPC if:
- The loot appears to your player on the floor on the same tick that the NPC is killed, or:
- If an item enters one of the player's containers at the same time as the NPC is killed.
This means that if a player were to swap weapons very quickly on the same tick an NPC is killed, the new item entering their inventory would be detected as having been received by an NPC.

This won't work for cases where:
- Somebody else dropped an item, and it appeared to the player on the same tick as they received an NPC kill, or:
- If they dropped an item and looted it on the same tick as the NPC was killed.

These cases would need to be handled more explicitly, using a dictionary of possible drops able to be received by each NPC (probably on the server-side), otherwise they will persist as there is no real way to combat them on the client.