### PR TITLE
Add PNG support and configurable image compression threshold

### DIFF
--- a/src/main/java/io/droptracker/DropTrackerConfig.java
+++ b/src/main/java/io/droptracker/DropTrackerConfig.java
@@ -298,6 +298,19 @@ public interface DropTrackerConfig extends Config {
         return VideoQuality.SCREENSHOT_ONLY;
     }
 
+    @ConfigItem(
+        keyName = "imageCompressionThresholdKb",
+        name = "Image Compression Threshold (KB)",
+        description = "<html>Maximum screenshot size (in KB) before JPEG compression is applied.<br>"
+            + "Screenshots smaller than this threshold are sent as lossless PNG.<br>"
+            + "Set to 0 to always compress to JPEG.</html>",
+        position = 9,
+        section = miscSettings
+    )
+    default int imageCompressionThresholdKb() {
+        return 500;
+    }
+
     /* API Configuration */
     @ConfigSection(
         name = "API Configuration",

--- a/src/main/java/io/droptracker/service/SubmissionManager.java
+++ b/src/main/java/io/droptracker/service/SubmissionManager.java
@@ -473,8 +473,10 @@ public class SubmissionManager {
                 .addFormDataPart("payload_json", GSON.toJson(webhook));
 
         if (screenshot != null) {
-            requestBodyBuilder.addFormDataPart("file", "image.jpeg",
-                    RequestBody.create(MediaType.parse("image/jpeg"), screenshot));
+            String mimeType = detectImageMimeType(screenshot);
+            String filename = mimeType.equals("image/png") ? "image.png" : "image.jpeg";
+            requestBodyBuilder.addFormDataPart("file", filename,
+                    RequestBody.create(MediaType.parse(mimeType), screenshot));
         }
 
         MultipartBody requestBody = requestBodyBuilder.build();
@@ -674,9 +676,14 @@ public class SubmissionManager {
 
             byte[] imageBytes = null;
             try {
-                imageBytes = convertImageToByteArray(bufferedImage);
-                if (imageBytes.length > 5 * 1024 * 1024) {
-                    // TODO: perform compression here
+                int thresholdBytes = config.imageCompressionThresholdKb() * 1024;
+                byte[] pngBytes = convertImageToPngBytes(bufferedImage);
+                if (thresholdBytes > 0 && pngBytes.length <= thresholdBytes) {
+                    // PNG is within the threshold — send lossless
+                    imageBytes = pngBytes;
+                } else {
+                    // PNG exceeds threshold (or threshold is 0) — compress to JPEG
+                    imageBytes = convertImageToJpegBytes(bufferedImage);
                 }
             } catch (IOException e) {
                 log.error("Error converting image to byte array", e);
@@ -837,10 +844,29 @@ public class SubmissionManager {
         }
     }
 
-    private static byte[] convertImageToByteArray(BufferedImage bufferedImage) throws IOException {
+    private static byte[] convertImageToJpegBytes(BufferedImage bufferedImage) throws IOException {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         ImageIO.write(bufferedImage, "jpeg", byteArrayOutputStream);
         return byteArrayOutputStream.toByteArray();
+    }
+
+    private static byte[] convertImageToPngBytes(BufferedImage bufferedImage) throws IOException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        ImageIO.write(bufferedImage, "png", byteArrayOutputStream);
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    /**
+     * Detects image MIME type from magic bytes.
+     * PNG files begin with 0x89 P N G; all others are treated as JPEG.
+     */
+    private static String detectImageMimeType(byte[] bytes) {
+        if (bytes != null && bytes.length >= 4
+                && bytes[0] == (byte) 0x89 && bytes[1] == 0x50
+                && bytes[2] == 0x4E && bytes[3] == 0x47) {
+            return "image/png";
+        }
+        return "image/jpeg";
     }
 
     // ========== Submission Management ==========


### PR DESCRIPTION
## Summary
This PR enhances screenshot handling by adding PNG format support and introducing a configurable compression threshold. Screenshots are now intelligently compressed based on size, with lossless PNG used for smaller images and JPEG compression applied only when necessary.

## Key Changes
- **PNG Format Support**: Screenshots are now captured as PNG (lossless) by default, with automatic MIME type detection based on file magic bytes
- **Configurable Compression Threshold**: Added `imageCompressionThresholdKb` config option (default: 500 KB) to control when JPEG compression is applied
  - Screenshots smaller than the threshold are sent as PNG
  - Screenshots exceeding the threshold are compressed to JPEG
  - Setting threshold to 0 forces JPEG compression for all images
- **Improved Image Conversion**: Split image conversion logic into separate methods:
  - `convertImageToJpegBytes()`: Converts BufferedImage to JPEG format
  - `convertImageToPngBytes()`: Converts BufferedImage to PNG format
  - `detectImageMimeType()`: Detects image format from magic bytes (PNG signature: 0x89 P N G)
- **Smart Webhook Payload**: The webhook now sends the correct filename and MIME type based on the actual image format

## Implementation Details
- PNG magic byte detection checks for the PNG file signature (0x89 0x50 0x4E 0x47) to determine format
- The compression logic prioritizes lossless PNG for smaller files, reducing quality loss while maintaining reasonable payload sizes
- Configuration is exposed in the UI under miscellaneous settings for easy adjustment