### PR TITLE
Treat LMS worlds as main-world submissions

### DIFF
--- a/src/main/java/io/droptracker/service/SubmissionManager.java
+++ b/src/main/java/io/droptracker/service/SubmissionManager.java
@@ -1145,6 +1145,8 @@ public class SubmissionManager {
      * Returns a string identifying the current world type for submission tagging.
      * Returns "MAIN" for regular game worlds, or the specific WorldType name for
      * temporary/special worlds (e.g. "BETA_WORLD", "DEADMAN", "SEASONAL").
+     * LAST_MAN_STANDING worlds are intentionally treated as MAIN because LMS is
+     * played on rotating main-game worlds.
      * Submissions from all world types are sent to the server; this field lets the
      * server separate main-game data from temporary-world data.
      */
@@ -1153,7 +1155,6 @@ public class SubmissionManager {
         if (worldType.contains(WorldType.BETA_WORLD))         return "BETA_WORLD";
         if (worldType.contains(WorldType.DEADMAN))            return "DEADMAN";
         if (worldType.contains(WorldType.FRESH_START_WORLD))  return "FRESH_START_WORLD";
-        if (worldType.contains(WorldType.LAST_MAN_STANDING))  return "LAST_MAN_STANDING";
         if (worldType.contains(WorldType.NOSAVE_MODE))        return "NOSAVE_MODE";
         if (worldType.contains(WorldType.PVP_ARENA))          return "PVP_ARENA";
         if (worldType.contains(WorldType.QUEST_SPEEDRUNNING)) return "QUEST_SPEEDRUNNING";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stop classifying `LAST_MAN_STANDING` as a special submission `world_type`
- allow LMS worlds to fall through to `MAIN` world tagging
- document why LMS is intentionally treated as main-world (rotating main-game worlds with a PvP mode)

## Validation
- targeted code inspection of `SubmissionManager#getWorldTypeName` confirms all previous special-world mappings remain unchanged except LMS
- attempted to run tests with `bash ./gradlew test`, but build tooling failed in this environment with `Unsupported class file major version 65` while compiling `settings.gradle`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab2150ca-052e-48d8-b2d1-a0b19eb6e856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab2150ca-052e-48d8-b2d1-a0b19eb6e856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

