### PR TITLE
Fix PB time tracking incorrectly capturing ToA target-time announcement

### DIFF
--- a/src/main/java/io/droptracker/events/PbHandler.java
+++ b/src/main/java/io/droptracker/events/PbHandler.java
@@ -139,6 +139,11 @@ public class PbHandler extends BaseEventHandler {
         if (message.startsWith("Preparation")) {
             return Optional.empty();
         }
+        // Ignore raid target-time announcements (e.g. "Your party failed to beat the overall target time of 40:00.")
+        // These contain a time string but are unrelated to the player's personal best.
+        if (message.contains("target time")) {
+            return Optional.empty();
+        }
 
         // Try boss count first
         Optional<Pair<String, Integer>> bossCount = parseBossCount(message);


### PR DESCRIPTION
Messages like "Your party failed to beat the overall target time of 40:00."
arrive after the actual completion time lines and were overwriting the stored
kill time because TIME_WITH_PB_PATTERN matched any time-formatted string.
Filter these messages out in parseMessage before they can corrupt kill data.

Fixes #35

https://claude.ai/code/session_011dxR6LkR2fgwEH89XVGPt7