### PR TITLE
Fix skilling pets submitted as Unknown Pet

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,6 @@
+# Force TLS 1.2 for dependency resolution.
+# JDK 11's TLS 1.3 handshake is rejected by Cloudflare (fronting repo.runelite.net)
+# with "Received fatal alert: handshake_failure", breaking dependency downloads.
+# Pinning TLS 1.2 avoids the broken 1.3 negotiation. Remove if building on JDK 17+.
+systemProp.jdk.tls.client.protocols=TLSv1.2
+systemProp.https.protocols=TLSv1.2

--- a/src/main/java/io/droptracker/events/PetHandler.java
+++ b/src/main/java/io/droptracker/events/PetHandler.java
@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
 import io.droptracker.service.KCService;
 import io.droptracker.util.ItemIDSearch;
 import io.droptracker.models.CustomWebhookBody;
+import io.droptracker.models.Pet;
 import io.droptracker.models.submissions.SubmissionType;
 import lombok.extern.slf4j.Slf4j;
 
@@ -267,11 +268,19 @@ public class PetHandler extends BaseEventHandler {
         return Character.toUpperCase(text.charAt(0)) + text.substring(1).toLowerCase();
     }
 
-    private static boolean isPetName(String itemName) {
-        return PET_TO_SOURCE.containsKey(ucFirst(itemName));
+    // Skilling pets (Beaver, Heron, Rocky, ...) have no boss source, so PET_TO_SOURCE
+    // alone isn't a complete pet list; the Pet enum carries them, PET_TO_SOURCE the newer
+    // boss pets it lacks. Accept a name present in either.
+    @VisibleForTesting
+    static boolean isPetName(String itemName) {
+        if (itemName == null) return false;
+        String name = ucFirst(itemName);
+        return Pet.findPet(name) != null || PET_TO_SOURCE.containsKey(name);
     }
 
-    // Simplified pet to source mapping - just for basic KC tracking
+    // Boss pet to source mapping - used for KC lookup. Skilling pets have no boss
+    // source; their source (the skill) is attributed server-side to avoid a plugin
+    // release per new pet and to keep skill names out of NPC resolution.
     private static final Map<String, String> PET_TO_SOURCE = Map.ofEntries(
         Map.entry("Abyssal orphan", "Abyssal Sire"),
         Map.entry("Baby mole", "Giant Mole"),

--- a/src/main/java/io/droptracker/models/Pet.java
+++ b/src/main/java/io/droptracker/models/Pet.java
@@ -87,7 +87,7 @@ public enum Pet
     private final String name;
     private final Integer iconID;
 
-    static Pet findPet(String petName)
+    public static Pet findPet(String petName)
     {
         for (Pet pet : values())
         {

--- a/src/test/java/io/droptracker/events/PetHandlerParseTest.java
+++ b/src/test/java/io/droptracker/events/PetHandlerParseTest.java
@@ -47,4 +47,24 @@ public class PetHandlerParseTest {
         assertEquals("Baby mole", m.group("pet"));
         assertEquals("200 kills.", m.group("milestone"));
     }
+
+    // Regression: skilling pets have no boss source and are absent from PET_TO_SOURCE,
+    // but must still be recognised via the Pet enum, else their name is dropped.
+    @Test
+    public void isPetNameRecognisesSkillingPets() {
+        for (String skillingPet : new String[]{
+                "Beaver", "Heron", "Rock golem", "Rocky", "Giant squirrel",
+                "Tangleroot", "Rift guardian", "Baby chinchompa"}) {
+            assertTrue(skillingPet + " should be recognised", PetHandler.isPetName(skillingPet));
+        }
+    }
+
+    @Test
+    public void isPetNameRecognisesBossPetsAndRejectsNonPets() {
+        // Newer boss pets live only in PET_TO_SOURCE, not the Pet enum.
+        assertTrue(PetHandler.isPetName("Yami"));
+        assertTrue(PetHandler.isPetName("Dom"));
+        assertTrue(PetHandler.isPetName("Baby mole"));
+        assertFalse(PetHandler.isPetName("Dragon warhammer"));
+    }
 }


### PR DESCRIPTION
### Problem
New skilling pets (Beaver, Heron, Rock golem, Rocky, Giant squirrel, Tangleroot, Rift guardian, Baby chinchompa) were uploaded as "Unknown Pet" with no source.

### Cause
`isPetName` only checked `PET_TO_SOURCE` (boss pets with a KC source), so the pet name parsed from the `New item added to your collection log: X` / `Untradeable drop: X` message was rejected for skilling pets and `pet_name` was never set — it stayed primed to `""` and shipped as "Unknown Pet".

### Fix
- Recognize the full pet list: `Pet.findPet(name) != null || PET_TO_SOURCE.containsKey(name)` (the `Pet` enum already carries skilling pets; `PET_TO_SOURCE` carries newer boss pets the enum lacks).
- Make `Pet.findPet` public; `isPetName` made package-private for testing.
- Add regression tests (6/6 pass).
- Pin TLS 1.2 in `gradle.properties` so dependency resolution from repo.runelite.net works on JDK 11 (Cloudflare rejects JDK 11's TLS 1.3 handshake with a fatal `handshake_failure`).

### Note
Pairs with the droptracker-core PR that attributes skilling-pet `source` server-side — the backend derives `source` from `pet_name`, so it needs this corrected name to help skilling pets end-to-end.
