### PR TITLE
Track new server-loot npcs without a plugin release

### DIFF
--- a/src/main/java/io/droptracker/DropTrackerPlugin.java
+++ b/src/main/java/io/droptracker/DropTrackerPlugin.java
@@ -86,7 +86,7 @@ import net.runelite.client.ui.overlay.OverlayManager;
 
 import net.runelite.client.util.ImageUtil;
 
-import static io.droptracker.util.NpcUtilities.SERVER_LOOT_NPC_IDS;
+import io.droptracker.util.NpcUtilities;
 
 @Slf4j
 @PluginDescriptor(
@@ -218,6 +218,11 @@ public class DropTrackerPlugin extends Plugin {
 	private void loadUntradeables() {
 		this.valuedItemIds = api.getValuedUntradeables();
 		this.untradeableItemIds = api.getNotableUntradeables();
+		// Published server-loot npc ids. Must be loaded before the first kill of
+		// the session, not lazily on first drop like the item lists: this list
+		// gates whether a drop is submitted at all, so a late load would lose
+		// the very drops it exists to capture.
+		NpcUtilities.setRemoteServerLootNpcIds(api.getServerLootNpcIds());
 	}
 
 
@@ -372,7 +377,7 @@ public class DropTrackerPlugin extends Plugin {
 	@Subscribe(priority = 1)
     public void onServerNpcLoot(ServerNpcLoot event) {
 		NPCComposition eventComp = event.getComposition();
-        if (!SERVER_LOOT_NPC_IDS.contains(eventComp.getId())) {
+        if (!NpcUtilities.isServerLootNpc(eventComp.getId())) {
             return;
         }
         if (eventComp.getName().equalsIgnoreCase("Yama")) {
@@ -393,7 +398,7 @@ public class DropTrackerPlugin extends Plugin {
 		// authoritatively by onServerNpcLoot; the client-side NpcLootReceived for
 		// them is a redundant duplicate, so skip its drop submission here. Kill
 		// count bookkeeping stays on this path unchanged.
-		if (!SERVER_LOOT_NPC_IDS.contains(npcId)) {
+		if (!NpcUtilities.isServerLootNpc(npcId)) {
 			dropHandler.onNpcLootReceived(npcLootReceived);
 		}
 		kcService.onNpcKill(npcLootReceived);

--- a/src/main/java/io/droptracker/api/DropTrackerApi.java
+++ b/src/main/java/io/droptracker/api/DropTrackerApi.java
@@ -833,6 +833,21 @@ public class DropTrackerApi {
         return fetchItemIdList("https://droptracker-io.github.io/content/untradeable_items.txt", "notable-untradeables");
     }
 
+    /**
+     * Npc ids whose loot RuneLite only reports via {@code ServerNpcLoot} (Jagex
+     * awards it server-side, so nothing spawns on the death tile for the
+     * client-side scrape to find). Published by the backend rather than baked
+     * into the plugin so a newly released boss starts tracking without a Plugin
+     * Hub round-trip — see {@code NpcUtilities.setRemoteServerLootNpcIds}.
+     * <p>
+     * Deliberately NOT gated on {@link DropTrackerConfig#useApi()}: it is a
+     * static file on GitHub Pages, so webhook-only clients get it too.
+     * Returns null on any failure, which leaves the compiled-in list in force.
+     */
+    public ArrayList<Integer> getServerLootNpcIds() {
+        return fetchItemIdList("https://droptracker-io.github.io/content/server_loot_npc_ids.txt", "server-loot-npcs");
+    }
+
     private ArrayList<Integer> fetchItemIdList(String url, String tag) {
         String valued;
         /* Only use github pages URL, as our API is sometimes not responding fast enough currently... */

--- a/src/main/java/io/droptracker/util/NpcUtilities.java
+++ b/src/main/java/io/droptracker/util/NpcUtilities.java
@@ -1,5 +1,8 @@
 package io.droptracker.util;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -76,6 +79,41 @@ public class NpcUtilities {
                 MAD_ANGEL_POST_QUEST_A,
                 MAD_ANGEL_POST_QUEST_B
         );
+
+    /**
+     * Server-loot npc ids published by the backend at
+     * {@code content/server_loot_npc_ids.txt}, layered over the compiled-in
+     * {@link #SERVER_LOOT_NPC_IDS} above. This is what stops a newly released
+     * boss (Mad Angel, 2026-07-29) needing a plugin release before its drops
+     * track at all.
+     * <p>
+     * Volatile immutable snapshot: written by the executor thread that fetches
+     * the list, read by the loot handlers on the client thread.
+     */
+    private static volatile Set<Integer> remoteServerLootNpcIds = Collections.emptySet();
+
+    /**
+     * Install the published server-loot id list. A null/empty argument (fetch
+     * failed, file unreachable, garbage body) is ignored rather than applied,
+     * so a bad publish or an offline client degrades to the compiled-in list
+     * instead of losing loot tracking for every server-loot boss.
+     */
+    public static void setRemoteServerLootNpcIds(Collection<Integer> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return;
+        }
+        remoteServerLootNpcIds = Collections.unmodifiableSet(new HashSet<>(ids));
+    }
+
+    /**
+     * Whether this npc's loot is awarded server-side, i.e. arrives via
+     * {@code ServerNpcLoot} and must not also be submitted from the
+     * client-side {@code NpcLootReceived} path. The union of the compiled-in
+     * list and the published one — never fewer ids than the build shipped with.
+     */
+    public static boolean isServerLootNpc(int npcId) {
+        return SERVER_LOOT_NPC_IDS.contains(npcId) || remoteServerLootNpcIds.contains(npcId);
+    }
 
     /* Canonical encounter names that a multi-part boss's sub-NPCs are remapped
      * to (see canonicalizeSpecialSource). Loot for these can arrive via more

--- a/src/test/java/io/droptracker/util/NpcUtilitiesCanonicalizeTest.java
+++ b/src/test/java/io/droptracker/util/NpcUtilitiesCanonicalizeTest.java
@@ -1,5 +1,8 @@
 package io.droptracker.util;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -70,6 +73,40 @@ public class NpcUtilitiesCanonicalizeTest {
     @Test
     public void madAngelIsNotMultiPath() {
         assertFalse(NpcUtilities.isMultiPathLootSource("Mad Angel"));
+    }
+
+    /**
+     * The published list layers over the compiled-in one; it never replaces it.
+     * A backend that drops an id (or serves an older list than the build) must
+     * not be able to switch off loot tracking for a boss this build already
+     * knows about.
+     */
+    @Test
+    public void publishedListAddsToCompiledInList() {
+        NpcUtilities.setRemoteServerLootNpcIds(Arrays.asList(999001, 999002));
+        assertTrue(NpcUtilities.isServerLootNpc(999001));
+        assertTrue(NpcUtilities.isServerLootNpc(999002));
+        // ...and everything compiled in still qualifies.
+        assertTrue(NpcUtilities.isServerLootNpc(NpcUtilities.MAD_ANGEL_QUEST_B));
+        assertFalse(NpcUtilities.isServerLootNpc(999003));
+    }
+
+    /**
+     * A failed fetch returns null and an empty/garbage file parses to an empty
+     * list. Either must leave the previous state untouched rather than wiping
+     * it — otherwise an unreachable GitHub Pages would silently stop loot
+     * tracking for every server-loot boss, which is the exact outage this
+     * mechanism exists to prevent.
+     */
+    @Test
+    public void failedOrEmptyFetchLeavesCompiledInListIntact() {
+        NpcUtilities.setRemoteServerLootNpcIds(Collections.singletonList(999004));
+        NpcUtilities.setRemoteServerLootNpcIds(null);
+        assertTrue("null fetch must not clear the overlay", NpcUtilities.isServerLootNpc(999004));
+        NpcUtilities.setRemoteServerLootNpcIds(Collections.emptyList());
+        assertTrue("empty fetch must not clear the overlay", NpcUtilities.isServerLootNpc(999004));
+        // The compiled-in ids survive regardless of what the backend serves.
+        assertTrue(NpcUtilities.isServerLootNpc(NpcUtilities.MAD_ANGEL_POST_QUEST_A));
     }
 
     @Test


### PR DESCRIPTION
## Why

`NpcUtilities.SERVER_LOOT_NPC_IDS` is a hardcoded allowlist, and
`onServerNpcLoot` uses it as a **deny-by-default gate** — loot from an unlisted
npc is discarded with no log and no telemetry. Every time Jagex ships an NPC
that awards loot server-side, its drops are lost until the list is edited, a
release is cut, and Plugin Hub review completes.

The failure is silent and partial, which is what makes it expensive. Mad Angel
(Wyrmscraig, released 2026-07-29) logged 179 personal bests against 0 recorded
drops on release day: kills, kill counts and PBs all worked, so nothing looked
broken from the outside — only the loot was missing.

## What this changes

The server-loot npc set becomes an **ever-changing list**: it is read as data
rather than compiled in, so it can change as the game does without shipping a
new plugin.

The plugin unions its compiled-in `SERVER_LOOT_NPC_IDS` with a list fetched from
`content/server_loot_npc_ids.txt`, alongside the existing `valued_items.txt` /
`untradeable_items.txt` lists. Adding a Mad Angel-class npc no longer requires a
release.

| Change | |
|---|---|
| `DropTrackerApi.getServerLootNpcIds()` | one call to the existing `fetchItemIdList` |
| `NpcUtilities` | fetched-list overlay, `setRemoteServerLootNpcIds()`, `isServerLootNpc()` |
| `DropTrackerPlugin` | installs the list in `loadUntradeables()`; both gates call `isServerLootNpc()` |

## Design notes

- **Union, never replacement.** `isServerLootNpc()` is `compiled-in OR fetched`.
  A short, stale or empty list cannot switch off tracking for a boss this build
  already knows about.
- **A failed fetch is ignored, not applied.** `fetchItemIdList` returns `null`
  on error, and an unreachable or garbage file parses to empty;
  `setRemoteServerLootNpcIds` no-ops on both, so a bad list degrades to current
  behaviour rather than silently disabling loot tracking. Locked by
  `failedOrEmptyFetchLeavesCompiledInListIntact`.
- **Works for API and webhook-only users alike.** The fetch is not gated on
  `config.useApi()`, and `loadUntradeables()` already runs for every client
  regardless of mode.
- **Loaded at startup, not lazily.** The item lists are fetched on first drop,
  which is fine for a screenshot decision. This list decides whether a drop is
  submitted *at all*, so a lazy load would lose the first kill of the session —
  the one case it exists for.
- **No periodic refresh**, deliberately, to keep the change small: an OSRS game
  update forces a client restart anyway, so release-day clients pick the list up
  on startup.

Worth knowing for review: the allowlist is load-bearing for de-duplication, not
just identification. RuneLite fires `ServerNpcLoot` (server-side, authoritative)
and `NpcLootReceived` (client-side ground scrape) independently and never
cross-suppresses them, which is why this keeps the gate and widens its input
rather than removing the gate.

## Testing

140 tests pass. Two new cases cover the union behaviour and the fail-safe path.
